### PR TITLE
Add sshpass for console

### DIFF
--- a/inventories/host_vars/console.yml
+++ b/inventories/host_vars/console.yml
@@ -24,6 +24,7 @@ apt:
   - p7zip-full
   - python3-pip
   - samba-common
+  - sshpass
   - vim
   - vlc
   - wireshark


### PR DESCRIPTION
新規作成したVM、かつ公開鍵を入れてないVMだと、ansibleを回したときにログインに失敗する
sshpassを導入したうえで、`ansible-playbook --ask-pass`で実行する