### PR TITLE
Zabbix agentのdebファイルをOSリリース毎のファイル名に合わせた

### DIFF
--- a/tasks/zabbix-agent2.yml
+++ b/tasks/zabbix-agent2.yml
@@ -2,7 +2,7 @@
 
 - name: Zabbix-agent2 repository install
   ansible.builtin.apt:
-    deb: https://repo.zabbix.com/zabbix/6.4/ubuntu/pool/main/z/zabbix-release/zabbix-release_6.4-1+ubuntu20.04_all.deb
+    deb: "https://repo.zabbix.com/zabbix/6.4/ubuntu/pool/main/z/zabbix-release/zabbix-release_6.4-1+ubuntu{{ ansible_facts['lsb']['release'] }}_all.deb"
 
 - name: Do apt update
   ansible.builtin.apt:


### PR DESCRIPTION
これでUbuntuのみであれば問題はないはず CentOS系はもう考えない