### PR TITLE
~/.ssh/configにSSHする先のユーザ名を追加する

### DIFF
--- a/inventories/host_vars/networks.yml
+++ b/inventories/host_vars/networks.yml
@@ -5,61 +5,73 @@ network:
     interface: ens160
     ipv4: 192.168.1.10
     shortname: vcsa
+    sshuser: root
   nuc01:
     hostname: nuc01.hayaworld.local
     interface: vmk0
     ipv4: 192.168.1.11
     shortname: nuc01
+    sshuser: root
   nuc02:
     hostname: nuc02.hayaworld.local
     interface: vmk0
     ipv4: 192.168.1.12
     shortname: nuc02
+    sshuser: root
   rui:
     hostname: rui.hayaworld.local
     interface: ens160
     ipv4: 192.168.1.100
     shortname: rui
+    sshuser: hayato
   win10:
     hostname: step.hayaworld.local
     interface: ens160
     ipv4: 192.168.1.101
     shortname: win10
+    shuser: none
   console:
     hostname: console.hayaworld.local
     interface: ens160
     ipv4: 192.168.1.105
     shortname: console
+    sshuser: root
   runner:
     hostname: runner.hayaworld.local
     interface: ens160
     ipv4: 192.168.1.104
     shortname: runner
+    sshuser: runner
   zabbix:
     hostname: zabbix.hayaworld.local
     interface: ens160
     ipv4: 192.168.1.106
     shortname: zabbix
+    sshuser: hayato
   step:
     hostname: step.hayaworld.local
     interface: ens160
     ipv4: 192.168.1.111
     shortname: step
+    sshuser: admin
   tm:
     hostname: tm.hayaworld.local
     interface: ens160
     ipv4: 192.168.1.112
     shortname: tm
+    sshuser: hayato
   jenkins:
     hostname: jenkins.hayaworld.local
     interface: ens160
     ipv4: 192.168.1.131
     shortname: jenkins
+    sshuser: hayato
   skylark:
     hostname: skylark.hayaworld.local
     interface: ens160
     ipv4: 192.168.1.200
     shortname: skylark
+    sshuser: hayato
 
 
 network_dhcp:

--- a/templates/mac/Users/hayato/.ssh/config.j2
+++ b/templates/mac/Users/hayato/.ssh/config.j2
@@ -11,6 +11,6 @@ Host github.com
 Host {{ host.shortname }}
   Hostname {{ host.hostname }}
   Port 22
-  User hayato
+  User {{ host.sshuser }}
 
 {% endfor %}


### PR DESCRIPTION
#138 の対応。基本的にhayatoでログインするようにしているが、一部アプライアンスは別ユーザで入らないといけない