### PR TITLE
Add Keepalive config on ~/.ssh/config on Mac

### DIFF
--- a/templates/mac/Users/hayato/.ssh/config.j2
+++ b/templates/mac/Users/hayato/.ssh/config.j2
@@ -2,6 +2,7 @@ AddKeysToAgent yes
 UseKeychain yes
 IdentityFile ~/.ssh/id_ed25519
 HostkeyAlgorithms +ssh-rsa
+ServerAliveInterval 60
 
 Host github.com
   Hostname ssh.github.com


### PR DESCRIPTION
#136 ssh接続時に長いこと接続がなかったときにSSHが切られる事象の解決