### PR TITLE
Skylarkの再インストールに気づいた点の修正

### DIFF
--- a/inventories/host_vars/skylark.yml
+++ b/inventories/host_vars/skylark.yml
@@ -1,7 +1,7 @@
 ---
 drives:
   skylark:
-    uuid: a2288da0-8a90-4f96-ac3a-a859f01ac187
+    uuid: e456364a-f704-4602-9962-334898e05359
     mountpoint: /skylark
     filesystem: "xfs"
     options: "defaults,noatime"

--- a/skylark.yml
+++ b/skylark.yml
@@ -49,10 +49,6 @@
       ansible.builtin.import_tasks:
         file: tasks/skylark/mount.yml
 
-    - name: Set XFS tuning
-      ansible.builtin.import_tasks:
-        file: tasks/skylark/xfs_tuning.yml
-
     - name: Set samba
       ansible.builtin.import_tasks:
         file: tasks/skylark/samba.yml

--- a/tasks/skylark/mount.yml
+++ b/tasks/skylark/mount.yml
@@ -5,7 +5,7 @@
     src: "UUID={{ drives.skylark.uuid }}"
     fstype: "{{ drives.skylark.filesystem }}"
     opts: "{{ drives.skylark.options }}"
-    state: present
+    state: mounted
 
 - name: Mount up device backup
   ansible.posix.mount:
@@ -13,4 +13,4 @@
     src: "UUID={{ drives.backup.uuid }}"
     fstype: "{{ drives.backup.filesystem }}"
     opts: "{{ drives.backup.options }}"
-    state: present
+    state: mounted


### PR DESCRIPTION
 - xfsオプションの削除
 - VMが変わったことにより、ディスクのデータ領域のUUIDが変更された、修正
 - 再起動時にデータ領域・backup領域がマウントされないのを修正 (#132)
