### PR TITLE
一旦apt-getでopenjdkをインストールするようにはした

### DIFF
--- a/inventories/host_vars/jenkins.yml
+++ b/inventories/host_vars/jenkins.yml
@@ -1,4 +1,5 @@
 ---
 apt:
   - jq
+  - openjdk-21-jdk
   - python3-pip

--- a/jenkins.yml
+++ b/jenkins.yml
@@ -42,6 +42,10 @@
       ansible.builtin.import_tasks:
         file: tasks/stop-cloud-init.yml
 
+    - name: Apt install
+      ansible.builtin.import_tasks:
+        file: tasks/jenkins/apt.yml
+
     - name: Install Jenkins
       ansible.builtin.import_role:
         name: geerlingguy.jenkins
@@ -53,10 +57,6 @@
         jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
       tags:
         - jenkins
-
-    - name: Apt install
-      ansible.builtin.import_tasks:
-        file: tasks/console/apt.yml
 
     - name: Install Pre-builded SNS downloaders
       ansible.builtin.import_tasks:

--- a/tasks/jenkins/apt.yml
+++ b/tasks/jenkins/apt.yml
@@ -1,0 +1,6 @@
+- name: Install Console modules
+  ansible.builtin.apt:
+    update_cache: true
+    pkg:
+      "{{ item }}"
+  loop: "{{ apt }}"


### PR DESCRIPTION
#141 対応
いずれはJenkinsインストール部分だけtaskに分解するほうが良さそう