### PR TITLE
Fix ffmpegthumbnailer creates thumbnail failed

### DIFF
--- a/console.yml
+++ b/console.yml
@@ -97,6 +97,10 @@
       ansible.builtin.import_tasks:
         file: tasks/sns_dl_linux.yml
 
+    - name: Fix ffmpegthumbnailer bugs
+      ansible.builtin.import_tasks:
+        file: tasks/console/ffmpegthumbnailer_fix.yml
+
     - name: Stop Apt-daily
       ansible.builtin.import_tasks:
         file: tasks/stop-apt-daily.yml

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -46,3 +46,9 @@
     name: multipathd
     state: restarted
   listen: "Restart multipathd"
+
+- name: Remove Nautilus cache dir
+  ansible.builtin.file:
+    path: /home/hayato/.cache/thumbnails/
+    state: absent
+  listen: "Remove nautilus cache"

--- a/tasks/console/ffmpegthumbnailer_fix.yml
+++ b/tasks/console/ffmpegthumbnailer_fix.yml
@@ -1,0 +1,17 @@
+---
+- name: "Make directory for ffmpegthumbnailer cache"
+  ansible.builtin.file:
+    path: "/home/hayato/.local/share/thumbnailers/"
+    state: directory
+    recurse: true
+    mode: '0755'
+
+- name: Make symlinks for User
+  ansible.builtin.file:
+    dest: "/home/hayato/.local/share/thumbnailers/ffmpegthumbnailer.thumbnailer"
+    src: "/usr/share/thumbnailers/ffmpegthumbnailer.thumbnailer"
+    owner: "hayato"
+    group: "hayato"
+    state: link
+    follow: true
+  notify: "Remove nautilus cache"


### PR DESCRIPTION
https://askubuntu.com/questions/1304654/file-manager-in-ubuntu-20-04-not-showing-thumbnails/1426435#1426435

```
$ ln -s /usr/share/thumbnailers/ffmpegthumbnailer.thumbnailer ~/.local/share/thumbnailers/ffmpegthumbnailer.thumbnailer
```