### PR TITLE
Configure ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,4 +1,3 @@
 [defaults]
 inventory = inventories/hosts
 forks = 6
-vault_password_file = vault_passwd

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,4 @@
+[defaults]
+inventory = inventories/hosts
+forks = 6
+vault_password_file = vault_passwd


### PR DESCRIPTION
ansible.cfgの設定追加。これで`-i invenroties/`のオプションが不要になる。

また高速化のTipsとして`pipeline`をTrueにするというのがあるけど、下記のAnsible Documentによると

> However this conflicts with privilege escalation (become). For example, when using ‘sudo:’ operations you must first disable ‘requiretty’ in /etc/sudoers on all managed hosts, which is why it is disabled by default.

と書いてあり、sudoers(5)にて「requirettyを無効」にしなければならない。
いやーなのでこれは設定しない。

https://docs.ansible.com/ansible/latest/reference_appendices/config.html#ansible-pipelining