### PR TITLE
Add mounting /home directory with btrfs compression

### DIFF
--- a/console.yml
+++ b/console.yml
@@ -88,3 +88,10 @@
       tags:
         - mega
         - mount
+
+    - name: Mount Home drive
+      ansible.builtin.import_tasks:
+        file: tasks/console/mount_home.yml
+      tags:
+        - home
+        - mount

--- a/inventories/host_vars/console.yml
+++ b/inventories/host_vars/console.yml
@@ -41,3 +41,6 @@ services_start:
 
 mega:
   UUID: "ed36eb83-c9eb-4e4b-90c5-9b1e36c64164"
+
+homedir:
+  UUID: "662c71dc-e20e-4ea5-8b1b-16386beac781"

--- a/tasks/console/mount_home.yml
+++ b/tasks/console/mount_home.yml
@@ -1,0 +1,22 @@
+---
+- name: "Check if exists /home"
+  ansible.builtin.stat:
+    path: "/home"
+    follow: true
+  register: homedir_stat
+  failed_when: homedir_stat.stat.isdir == false
+
+- name: "Check if exists homedir drive"
+  ansible.builtin.stat:
+    path: "/dev/disk/by-uuid/{{ homedir.UUID }}"
+    follow: true
+  register: home_drive
+  failed_when: home_drive.stat.isblk == false
+
+- name: "Mount Homedir Drive"
+  ansible.posix.mount:
+    src: "UUID={{ homedir.UUID }}"
+    path: "/home"
+    opts: "defaults,compress=zstd"
+    fstype: btrfs
+    state: mounted


### PR DESCRIPTION
```
console.hayaworld.home[~]% sudo mkfs.btrfs /dev/sdc1
btrfs-progs v5.16.2
See http://btrfs.wiki.kernel.org for more information.

Performing full device TRIM /dev/sdc1 (55.00GiB) ...
NOTE: several default settings have changed in version 5.15, please make sure
      this does not affect your deployments:
      - DUP for metadata (-m dup)
      - enabled no-holes (-O no-holes)
      - enabled free-space-tree (-R free-space-tree)

Label:              (null)
UUID:               662c71dc-e20e-4ea5-8b1b-16386beac781
Node size:          16384
Sector size:        4096
Filesystem size:    55.00GiB
Block group profiles:
  Data:             single            8.00MiB
  Metadata:         DUP               1.00GiB
  System:           DUP               8.00MiB
SSD detected:       no
Zoned device:       no
Incompat features:  extref, skinny-metadata, no-holes
Runtime features:   free-space-tree
Checksum:           crc32c
Number of devices:  1
Devices:
   ID        SIZE  PATH
    1    55.00GiB  /dev/sdc1
```