### PR TITLE
Fix mrlesmithjr/ansible-netplan version

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -5,6 +5,8 @@ roles:
   - name: geerlingguy.docker
   - name: geerlingguy.jenkins
   - name: mrlesmithjr.netplan
+    src: https://github.com/mrlesmithjr/ansible-netplan
+    version: 'f0167f5'
 
 collections:
   - name: ansible.posix


### PR DESCRIPTION
https://github.com/mrlesmithjr/ansible-netplan/issues/52 このバグ
- Ansible-galaxyに登録されているバージョンよりもコミットが進んでいるのに、ansible-galaxyのリポジトリに反映されてない
  - Ubuntu 24.04 ではnplanというパッケージが削除されたことに追従しているコミットがある

をテンポラリに修正するやつ。