### PR TITLE
Changed Skylark Backup USB-HDD

### DIFF
--- a/inventories/host_vars/skylark.yml
+++ b/inventories/host_vars/skylark.yml
@@ -6,10 +6,21 @@ drives:
     filesystem: "btrfs"
     options: "defaults,noatime"
   backup:
-    uuid: 77af48a6-5a47-4e06-a106-c5c74b6d1449
-    mountpoint: /backup
-    filesystem: "btrfs"
-    options: "defaults,users,noatime"
+    - uuid: 77af48a6-5a47-4e06-a106-c5c74b6d1449
+      mountpoint: /backup/hayato
+      subvol: "/hayato"
+      filesystem: "btrfs"
+      options: "defaults,users,noatime,compress=zstd"
+    - uuid: 77af48a6-5a47-4e06-a106-c5c74b6d1449
+      mountpoint: /backup/Nullpo
+      subvol: "/Nullpo"
+      filesystem: "btrfs"
+      options: "defaults,users,noatime,compress=zstd"
+    - uuid: 77af48a6-5a47-4e06-a106-c5c74b6d1449
+      mountpoint: /backup/snapshots
+      subvol: "/snapshots"
+      filesystem: "btrfs"
+      options: "defaults,users,noatime,compress=zstd"
 
 services_start:
   - nmbd

--- a/skylark.yml
+++ b/skylark.yml
@@ -22,6 +22,8 @@
     - name: Set mount(5)
       ansible.builtin.import_tasks:
         file: tasks/skylark/mount.yml
+      tags:
+        - mount
 
     - name: Set samba
       ansible.builtin.import_tasks:

--- a/tasks/skylark/mount.yml
+++ b/tasks/skylark/mount.yml
@@ -16,8 +16,9 @@
 
 - name: Mount up device backup
   ansible.posix.mount:
-    path: "{{ drives.backup.mountpoint }}"
-    src: "UUID={{ drives.backup.uuid }}"
-    fstype: "{{ drives.backup.filesystem }}"
-    opts: "{{ drives.backup.options }}"
+    path: "{{ item.mountpoint }}"
+    src: "UUID={{ item.uuid }}"
+    fstype: "{{ item.filesystem }}"
+    opts: "subvol={{ item.subvol }},{{ item.options }}"
     state: mounted
+  loop: "{{ drives.backup }}"

--- a/templates/skylark/home/hayato/backupscripts/incrementalNullpoBackup.sh
+++ b/templates/skylark/home/hayato/backupscripts/incrementalNullpoBackup.sh
@@ -2,7 +2,7 @@
 
 NULLPODIR='/skylark/Nullpo/'
 DESTDIR='/backup/Nullpo'
-DESTDEVICE='/dev/sdc1'
+SNAPSHOTSDIR='/backup/snapshots/Nullpo'
 
 # マウントされていれば1
 ISMOUNT=$(mount | grep "${DESTDEVICE}" | wc -l)
@@ -13,8 +13,7 @@ if [ ! ${ISMOUNT} ]; then
     exit 1
 fi
 
-LINKDEST=`ls -1l ${DESTDIR} | awk '{print $9}' | tr -d '/' | sort -n | tail -1`
-TODAY=`date +%Y%m%d_%H%M%S`
+TODAY=$(date +%Y%m%d_%H%M%S)
 
 if [ -e ${DESTDIR}/sentinel ]; then
     echo "[ERROR] Previous operation is abnormaly finished." >&2
@@ -23,10 +22,10 @@ if [ -e ${DESTDIR}/sentinel ]; then
     exit 2
 fi
 
+# rsync
 touch ${DESTDIR}/sentinel
-
-echo "rsync -av8  --link-dest=../${LINKDEST}/ ${NULLPODIR} ${DESTDIR}/${TODAY}"
-rsync -av8 --link-dest=../${LINKDEST}/ ${NULLPODIR} ${DESTDIR}/${TODAY}
+echo "rsync -av8 ${NULLPODIR} ${DESTDIR}"
+rsync -av8 ${NULLPODIR} ${DESTDIR}
 RETVAL=$?
 
 if [ ! $RETVAL ]; then
@@ -36,3 +35,6 @@ if [ ! $RETVAL ]; then
 fi
 
 rm ${DESTDIR}/sentinel
+
+# Snapshot 作成
+sudo btrfs subvolume snapshot -r "${DESTDIR}" "${SNAPSHOTSDIR}/${TODAY}"


### PR DESCRIPTION
バックアップ用のUSB-HDDの故障に伴い、
- バックアップHDDを新調
- btrfsを採用
 - data-duplicationの採用
 - backupscriptはシンボリックリンク(--link-dest)ではなく、btrfsのスナップショットに変更した
