### PR TITLE
IPv6 address/DNS configuration fix

### DIFF
--- a/host_vars/mai.yml
+++ b/host_vars/mai.yml
@@ -23,6 +23,9 @@ dnsmasq:
   logs:
     log_facility: local5
     log_to: "log.hayaworld.home"
+  ipv6:
+    dns6_server_self: "{{ mai_info.ipv6_addr }}"
+    dns6_server_other: "{{ rui_info.ipv6_addr }}"
 
 services_start:
   - dnsmasq

--- a/host_vars/mai.yml
+++ b/host_vars/mai.yml
@@ -14,8 +14,7 @@ dnsmasq:
     ttl: "12h"
   dhcp_option:
     ntp_server: 210.130.188.10
-    dns4_self: "{{ mai_info.ipv4 }}"
-    dns4_other: "{{ rui_info.ipv4 }}"
+    dns_server: "{{ mai_info.ipv4 }},{{ rui_info.ipv4 }}"
     router: "{{ subnet.gw4 }}"
     netmask: "255.255.255.0"
   dns:
@@ -24,13 +23,6 @@ dnsmasq:
   logs:
     log_facility: local5
     log_to: "log.hayaworld.home"
-  ipv6:
-    dhcp_range:
-      start: "2000"
-      end: "2fff"
-      ttl: "12h"
-    dns6_server_self: "{{ mai_info.ipv6_addr }}"
-    dns6_server_other: "{{ rui_info.ipv6_addr }}"
 
 services_start:
   - dnsmasq

--- a/host_vars/rui.yml
+++ b/host_vars/rui.yml
@@ -14,8 +14,7 @@ dnsmasq:
     ttl: "12h"
   dhcp_option:
     ntp_server: 210.130.188.10
-    dns4_self: "{{ rui_info.ipv4 }}"
-    dns4_other: "{{ mai_info.ipv4 }}"
+    dns_server: "{{ rui_info.ipv4 }},{{ mai_info.ipv4 }}"
     router: "{{ subnet.gw4 }}"
     netmask: "255.255.255.0"
   dns:
@@ -24,13 +23,6 @@ dnsmasq:
   logs:
     log_facility: local5
     log_to: "log.hayaworld.home"
-  ipv6:
-    dhcp_range:
-      start: "2000"
-      end: "2fff"
-      ttl: "12h"
-    dns6_server_self: "{{ rui_info.ipv6_addr }}"
-    dns6_server_other: "{{ mai_info.ipv6_addr }}"
 
 services_start:
   - dnsmasq

--- a/host_vars/rui.yml
+++ b/host_vars/rui.yml
@@ -23,6 +23,9 @@ dnsmasq:
   logs:
     log_facility: local5
     log_to: "log.hayaworld.home"
+  ipv6:
+    dns6_server_self: "{{ rui_info.ipv6_addr }}"
+    dns6_server_other: "{{ mai_info.ipv6_addr }}"
 
 services_start:
   - dnsmasq

--- a/roles/dns/templates/etc/dnsmasq.conf.j2
+++ b/roles/dns/templates/etc/dnsmasq.conf.j2
@@ -8,17 +8,10 @@ interface={{ dnsmasq.interface }}
 
 dhcp-range=lan,{{ dnsmasq.dhcp_range.start }},{{ dnsmasq.dhcp_range.end }},{{ dnsmasq.dhcp_range.netmask }},{{ dnsmasq.dhcp_range.ttl }}
 
-dhcp-option=option:dns-server,{{ dnsmasq.dhcp_option.dns4_self }},{{ dnsmasq.dhcp_option.dns4_other }}
+dhcp-option=option:dns-server,{{ dnsmasq.dhcp_option.dns_server }}
 dhcp-option=option:netmask,{{ dnsmasq.dhcp_option.netmask }}
 dhcp-option=option:ntp-server,{{ dnsmasq.dhcp_option.ntp_server }}
 dhcp-option=option:router,{{ dnsmasq.dhcp_option.router }}
-
-# IPv6
-ra-param={{ dnsmasq.interface }},high,0,0
-quiet-ra
-dhcp-range=::{{ dnsmasq.ipv6.dhcp_range.start }},::{{ dnsmasq.ipv6.dhcp_range.end }},constructor:{{ dnsmasq.interface }},ra-names,slaac,{{ dnsmasq.ipv6.dhcp_range.ttl }}
-dhcp-option=option6:dns-server,[{{ dnsmasq.ipv6.dns6_server_self }}],[{{ dnsmasq.ipv6.dns6_server_other }}]
-dhcp-option=option6:information-refresh-time,6h
 
 cache-size={{ dnsmasq.dns.cache_size }}
 dhcp-sequential-ip

--- a/roles/dns/templates/etc/dnsmasq.d/resolv.txt.j2
+++ b/roles/dns/templates/etc/dnsmasq.d/resolv.txt.j2
@@ -1,2 +1,3 @@
-server={{ outer_dns_servers.ipv4 }}
-server={{ outer_dns_servers.ipv6 }}
+{% for resolver in subnet.dns4 %}
+server={{ resolver }}
+{% endfor %}

--- a/roles/dns/templates/etc/dnsmasq.d/resolv.txt.j2
+++ b/roles/dns/templates/etc/dnsmasq.d/resolv.txt.j2
@@ -1,3 +1,2 @@
-{% for resolver in subnet.dns4 %}
-server={{ resolver }}
-{% endfor %}
+server={{ outer_dns_servers.ipv4 }}
+server={{ outer_dns_servers.ipv6 }}

--- a/roles/dns/templates/etc/radvd.conf.j2
+++ b/roles/dns/templates/etc/radvd.conf.j2
@@ -1,10 +1,20 @@
 interface {{ dnsmasq.interface }} {
-    AdvDefaultPreference high;
-    AdvManagedFlag on;
-    AdvOtherConfigFlag on;
-    AdvSendAdvert on;
-    MaxRtrAdvInterval 100;
-    MinRtrAdvInterval 30;
-    prefix {{ ipv6.ula.prefix }}::/64 {};
-    RDNSS {{ dnsmasq.ipv6.dns6_server_self }} {{ dnsmasq.ipv6.dns6_server_other }} { };
+  AdvDefaultPreference high;
+  AdvHomeAgentFlag off;
+  AdvManagedFlag off;
+  AdvOtherConfigFlag off;
+  AdvSendAdvert on;
+  MaxRtrAdvInterval 100;
+  MinRtrAdvInterval 30;
+  prefix {{ ipv6.ula.prefix }}::/64 {
+    AdvOnLink on;
+    AdvAutonomous on;
+    AdvRouterAddr off;
+  };
+  RDNSS {{ dnsmasq.ipv6.dns6_server_self }} {
+    AdvRDNSSPreference 8;
+    AdvRDNSSOpen off;
+    AdvRDNSSLifetime 30;
+  };
+  DNSSL {{ dnsmasq.domain }} {};
 };


### PR DESCRIPTION
前回のPRで参照していたURLでの情報は誤り。RA+SLACCにするには
- A: true (このセグメントではSLACCを使用せよ)
- O: false (アドレス設定にDHCPv6は使用しない)
- M: false (SLACCで適用できる設定以外はDHCPv6を使用しない=RAの付加情報を使用せよ)

https://www.nic.ad.jp/ja/materials/iw/2017/proceedings/s03/s3-kitaguchi.pdf

であるべきだった。DNSmasqもRAをしゃべれるが、同一サブネットにRAを話すノードが3つもあるのはおかしいのでradvdのみにした。

iOSやmacOSは設定反映後にOSの再起動が必要。